### PR TITLE
Refactor: 그룹 참여 기능 리팩토링 (react-query 적용)

### DIFF
--- a/.gemini/styleguide.me
+++ b/.gemini/styleguide.me
@@ -1,0 +1,2 @@
+Write Comment in Korean language.
+코드 리뷰 코멘트를 한국어로 작성해.

--- a/src/features/group/screens/GroupListScreen/components/JoinGroupSheet.tsx
+++ b/src/features/group/screens/GroupListScreen/components/JoinGroupSheet.tsx
@@ -1,18 +1,26 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, Input, Sheet, Text, YStack } from "tamagui";
 
 interface JoinGroupSheetProps {
   isOpen: boolean;
   onClose: () => void;
   onJoin: (code: string) => void;
+  isPending?: boolean;
 }
 
 export default function JoinGroupSheet({
   isOpen,
   onClose,
   onJoin,
+  isPending,
 }: JoinGroupSheetProps) {
   const [code, setCode] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCode("");
+    }
+  }, [isOpen]);
 
   return (
     <Sheet
@@ -43,8 +51,10 @@ export default function JoinGroupSheet({
             onChangeText={setCode}
           />
           <YStack gap={8}>
-            <Button onPress={() => onJoin(code)}>참여</Button>
-            <Button variant="outlined" onPress={onClose}>
+            <Button onPress={() => onJoin(code)} disabled={isPending}>
+              {isPending ? "참여 중..." : "참여"}
+            </Button>
+            <Button variant="outlined" onPress={onClose} disabled={isPending}>
               닫기
             </Button>
           </YStack>

--- a/src/features/group/screens/GroupListScreen/hooks/mutations/useJoinGroupMutation.ts
+++ b/src/features/group/screens/GroupListScreen/hooks/mutations/useJoinGroupMutation.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { joinGroup } from "../../services/api";
+
+export const useJoinGroupMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: joinGroup,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["groups"] });
+    },
+  });
+};

--- a/src/features/group/screens/GroupListScreen/index.tsx
+++ b/src/features/group/screens/GroupListScreen/index.tsx
@@ -1,6 +1,6 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useToastController } from "@tamagui/toast";
 import { useState } from "react";
 import { ScrollView } from "tamagui";
 
@@ -9,6 +9,7 @@ import JoinGroupSheet from "@/features/group/screens/GroupListScreen/components/
 import { RootStackParamList } from "@/types/navigation.types";
 import GroupActionSheet from "./components/GroupActionSheet";
 import GroupList from "./components/GroupList";
+import { useJoinGroupMutation } from "./hooks/mutations/useJoinGroupMutation";
 
 type GroupListScreenNavigationProp = NativeStackNavigationProp<
   RootStackParamList,
@@ -17,36 +18,26 @@ type GroupListScreenNavigationProp = NativeStackNavigationProp<
 
 export default function GroupListScreen() {
   const navigation = useNavigation<GroupListScreenNavigationProp>();
+  const toast = useToastController();
+
+  const joinGroupMutation = useJoinGroupMutation();
 
   const [isActionOpen, setActionOpen] = useState(false);
   const [isJoinOpen, setJoinOpen] = useState(false);
 
-  const handleJoinGroup = async (code: string) => {
-    try {
-      const token = await AsyncStorage.getItem("token");
-      const res = await fetch(
-        `${process.env.EXPO_PUBLIC_API_BASE_URL}/api/groups/join`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ code }),
-        }
-      );
-
-      if (res.ok) {
-        alert("그룹에 참여했습니다!");
-        // refetch();
+  const handleJoinGroup = (code: string) => {
+    joinGroupMutation.mutate(code, {
+      onSuccess: () => {
+        toast.show("그룹에 참여했습니다!", { native: true });
         setJoinOpen(false);
-      } else {
-        alert("참여에 실패했습니다.");
-      }
-    } catch (e) {
-      console.error("그룹 참여 오류:", e);
-      alert("참여 중 오류가 발생했습니다.");
-    }
+      },
+      onError: (error) => {
+        toast.show("참여 중 오류가 발생했습니다.", {
+          native: true,
+          message: error.message,
+        });
+      },
+    });
   };
 
   return (
@@ -58,6 +49,7 @@ export default function GroupListScreen() {
         isOpen={isJoinOpen}
         onClose={() => setJoinOpen(false)}
         onJoin={handleJoinGroup}
+        isPending={joinGroupMutation.isPending}
       />
       <GroupActionSheet
         open={isActionOpen}

--- a/src/features/group/screens/GroupListScreen/services/api.ts
+++ b/src/features/group/screens/GroupListScreen/services/api.ts
@@ -12,3 +12,26 @@ export const fetchGroups = async (): Promise<Group[]> => {
   });
   return response.data;
 };
+
+export const joinGroup = async (code: string) => {
+  const token = await AsyncStorage.getItem("token");
+  try {
+    const response = await axios.post(
+      `${baseUrl}/api/groups/join`,
+      { code },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(
+        error.response.data.message || "그룹 참여에 실패했습니다."
+      );
+    }
+    throw new Error("참여 중 오류가 발생했습니다.");
+  }
+};


### PR DESCRIPTION
## 주요 변경 내용

* `react-query`의 `useMutation`을 사용하여 그룹 참여 API 호출 로직을 `useJoinGroupMutation` 훅으로 분리했습니다.
* 그룹 참여 API 호출의 로딩 및 에러 상태를 관리하고, 사용자에게 토스트 메시지로 피드백을 제공하도록 UI를 개선했습니다.
* `JoinGroupSheet` 컴포넌트에서 API 호출 로직을 분리하여 코드의 재사용성과 유지보수성을 향상시켰습니다.