### PR TITLE
feat: Refresh token 및 인증 로직 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lucide-react-native": "^0.525.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.60.0",
     "react-native": "0.81.5",
     "react-native-keyboard-controller": "1.18.5",
@@ -50,7 +51,8 @@
     "react-native-worklets": "0.5.1",
     "tamagui": "1.129.13",
     "uuid": "^11.1.0",
-    "zod": "^4.0.5"
+    "zod": "^4.0.5",
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { ToastProvider, ToastViewport } from "@tamagui/toast";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Suspense, useEffect, useState } from "react";
+import {
+  QueryClientProvider,
+  QueryErrorResetBoundary,
+} from "@tanstack/react-query";
+import { useEffect } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 
+import ErrorFallback from "@/components/ErrorFallback";
 import DevLoginScreen from "@/features/auth/screens/DevLoginScreen";
 import LoginScreen from "@/features/auth/screens/LoginScreen";
-import { getAccessToken } from "@/features/auth/utils/tokenManager";
 import DiaryCreateScreen from "@/features/diary/screens/DiaryCreateScreen";
 import DiaryDetailScreen from "@/features/diary/screens/DiaryDetailScreen";
 import GroupCreateScreen from "@/features/group/screens/GroupCreateScreen";
@@ -17,16 +21,11 @@ import { ActivityIndicator, Platform, StatusBar, View } from "react-native";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { TamaguiProvider } from "tamagui";
 import { config } from "../tamagui.config";
+import ScreenLayout from "./components/layouts/ScreenLayout";
+import { useAuthStore } from "./features/auth/stores/authStore";
+import { queryClient } from "./services/queryClient";
 
 const Stack = createNativeStackNavigator();
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 5 * 60 * 1000, // 예: 5분
-    },
-  },
-});
 
 const linking = {
   prefixes: [Platform.OS === "web" ? window.location.origin : "uriary://"],
@@ -42,17 +41,10 @@ const linking = {
 };
 
 export default function App() {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const { isAuthenticated, isLoading, initialize } = useAuthStore();
 
   useEffect(() => {
-    const checkToken = async () => {
-      const accessToken = await getAccessToken();
-      setIsLoggedIn(!!accessToken);
-      setIsLoading(false);
-    };
-
-    checkToken();
+    initialize(); // 앱 구동 시 1회 실행
   }, []);
 
   if (isLoading) {
@@ -81,34 +73,60 @@ export default function App() {
           <SafeAreaProvider>
             <StatusBar />
             <SafeAreaView style={{ flex: 1 }}>
-              <NavigationContainer linking={linking}>
-                <Suspense>
-                  <Stack.Navigator
-                    initialRouteName={isLoggedIn ? "Home" : "Login"}
-                    screenOptions={{ headerShown: false }}
+              <QueryErrorResetBoundary>
+                {({ reset }) => (
+                  <ErrorBoundary
+                    key={isAuthenticated ? "auth" : "guest"}
+                    onReset={reset}
+                    fallbackRender={({ resetErrorBoundary, error }) => (
+                      <ErrorFallback
+                        error={error}
+                        resetError={resetErrorBoundary}
+                      />
+                    )}
                   >
-                    <Stack.Screen name="Home" component={GroupListScreen} />
-                    <Stack.Screen name="Login" component={LoginScreen} />
-                    <Stack.Screen name="DevLogin" component={DevLoginScreen} />
-                    <Stack.Screen name="Group" component={GroupScreen} />
-                    <Stack.Screen
-                      name="GroupCreate"
-                      component={GroupCreateScreen}
-                      options={{
-                        presentation: "modal",
-                        animation: "slide_from_bottom",
-                      }}
-                    />
-                    <Stack.Screen
-                      name="DiaryCreate"
-                      component={DiaryCreateScreen}
-                      options={{ title: "일기 작성" }}
-                    />
-                    <Stack.Screen name="Diary" component={DiaryDetailScreen} />
-                    <Stack.Screen name="Setting" component={SettingScreen} />
-                  </Stack.Navigator>
-                </Suspense>
-              </NavigationContainer>
+                    <ScreenLayout>
+                      <NavigationContainer linking={linking}>
+                        <Stack.Navigator
+                          initialRouteName={isAuthenticated ? "Home" : "Login"}
+                          screenOptions={{ headerShown: false }}
+                        >
+                          <Stack.Screen
+                            name="Home"
+                            component={GroupListScreen}
+                          />
+                          <Stack.Screen name="Group" component={GroupScreen} />
+                          <Stack.Screen
+                            name="GroupCreate"
+                            component={GroupCreateScreen}
+                            options={{
+                              presentation: "modal",
+                              animation: "slide_from_bottom",
+                            }}
+                          />
+                          <Stack.Screen
+                            name="DiaryCreate"
+                            component={DiaryCreateScreen}
+                          />
+                          <Stack.Screen
+                            name="Diary"
+                            component={DiaryDetailScreen}
+                          />
+                          <Stack.Screen
+                            name="Setting"
+                            component={SettingScreen}
+                          />
+                          <Stack.Screen name="Login" component={LoginScreen} />
+                          <Stack.Screen
+                            name="DevLogin"
+                            component={DevLoginScreen}
+                          />
+                        </Stack.Navigator>
+                      </NavigationContainer>
+                    </ScreenLayout>
+                  </ErrorBoundary>
+                )}
+              </QueryErrorResetBoundary>
             </SafeAreaView>
           </SafeAreaProvider>
         </ToastProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,6 +107,7 @@ export default function App() {
                           <Stack.Screen
                             name="DiaryCreate"
                             component={DiaryCreateScreen}
+                            options={{ title: "일기 작성" }}
                           />
                           <Stack.Screen
                             name="Diary"

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,54 @@
+import { useAuthStore } from "@/features/auth/stores/authStore";
+import axios from "axios";
+import { AlertTriangle } from "lucide-react-native";
+import { useEffect } from "react";
+import { Button, styled, Text, YStack } from "tamagui";
+
+interface Props {
+  error: Error;
+  resetError: () => void;
+}
+const StyledAlertTriangle = styled(AlertTriangle, {
+  name: "StyledAlertTriangle",
+});
+
+const ErrorFallback = ({ error, resetError }: Props) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  useEffect(() => {
+    // 에러가 발생했는데 이미 로그아웃 상태(isAuthenticated === false)라면
+    // 또는 에러 코드 자체가 401이라면
+    if (
+      (axios.isAxiosError(error) && error.response?.status === 401) ||
+      !isAuthenticated
+    ) {
+      // 에러 바운더리를 초기화하여 내비게이션이 다시 그려지도록 유도
+      resetError();
+    }
+  }, [error, isAuthenticated, resetError]);
+
+  if (axios.isAxiosError(error) && error.response?.status === 401) {
+    return null;
+  }
+  return (
+    <YStack
+      flex={1}
+      justifyContent="center"
+      alignItems="center"
+      gap={16}
+      padding={20}
+    >
+      <StyledAlertTriangle size={48} color="$red10" />
+      <YStack gap={4} alignItems="center">
+        <Text fontSize="$6" fontWeight="bold" color="$color12">
+          에러가 발생했습니다.
+        </Text>
+        <Text fontSize="$4" color="$color11" textAlign="center">
+          {error.message}
+        </Text>
+      </YStack>
+      <Button onPress={resetError}>재시도</Button>
+    </YStack>
+  );
+};
+
+export default ErrorFallback;

--- a/src/components/SuspenseFallback.tsx
+++ b/src/components/SuspenseFallback.tsx
@@ -1,0 +1,10 @@
+
+import { Spinner, YStack } from "tamagui";
+
+export default function SuspenseFallback() {
+  return (
+    <YStack flex={1} justifyContent="center" alignItems="center">
+      <Spinner size="large" color="$orange10" />
+    </YStack>
+  );
+}

--- a/src/components/layouts/ScreenLayout.tsx
+++ b/src/components/layouts/ScreenLayout.tsx
@@ -1,0 +1,7 @@
+
+import SuspenseFallback from "@/components/SuspenseFallback";
+import { Suspense } from "react";
+
+export default function ScreenLayout({ children }: { children: React.ReactNode }) {
+  return <Suspense fallback={<SuspenseFallback />}>{children}</Suspense>;
+}

--- a/src/features/auth/screens/LoginScreen/index.tsx
+++ b/src/features/auth/screens/LoginScreen/index.tsx
@@ -7,6 +7,7 @@ import Constants from "expo-constants";
 import * as Linking from "expo-linking";
 import { useEffect } from "react";
 import { Button, Text, XStack, YStack } from "tamagui";
+import { useAuthStore } from "../../stores/authStore";
 import KakaoSymbol from "./icons/KakaoSymbol";
 
 type Navigation = NativeStackNavigationProp<RootStackParamList, "Login">;
@@ -15,6 +16,7 @@ const API_BASE_URL = Constants.expoConfig?.extra?.eas?.apiBaseUrl;
 
 export default function LoginScreen() {
   const navigation = useNavigation<Navigation>();
+  const login = useAuthStore((store) => store.login);
 
   useEffect(() => {
     const handleDeepLink = async ({ url }: { url: string }) => {
@@ -27,6 +29,7 @@ export default function LoginScreen() {
             code
           );
           await storeTokens({ accessToken, refreshToken });
+          login();
           navigation.navigate("Home");
         } catch (error) {
           console.error("Failed to exchange code for tokens:", error);

--- a/src/features/auth/stores/authStore.ts
+++ b/src/features/auth/stores/authStore.ts
@@ -1,0 +1,39 @@
+import {
+  clearTokens,
+  getAccessToken,
+} from "@/features/auth/utils/tokenManager";
+import { queryClient } from "@/services/queryClient";
+import { create } from "zustand";
+
+interface AuthState {
+  isAuthenticated: boolean;
+  isLoading: boolean; // 앱 초기 토큰 검사 상태
+  login: () => void;
+  logout: () => Promise<void>;
+  initialize: () => Promise<void>; // 앱 시작 시 실행할 함수
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isAuthenticated: false,
+  isLoading: true,
+
+  login: () => set({ isAuthenticated: true }),
+
+  // 1. 비동기로 토큰을 지우고 상태를 변경합니다.
+  logout: async () => {
+    await clearTokens();
+    queryClient.cancelQueries();
+    queryClient.clear();
+    set({ isAuthenticated: false });
+  },
+
+  // 2. 앱이 켜질 때 저장된 토큰이 있는지 확인합니다.
+  initialize: async () => {
+    try {
+      const token = await getAccessToken();
+      set({ isAuthenticated: !!token });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));

--- a/src/features/group/screens/GroupListScreen/components/GroupList.tsx
+++ b/src/features/group/screens/GroupListScreen/components/GroupList.tsx
@@ -1,6 +1,6 @@
 import EmptyPlaceholder from "@/components/EmptyPlaceholder";
 import { Group } from "@/features/group/types/group.types";
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { Users } from "lucide-react-native";
 import { FlatList } from "react-native";
 import { useTheme } from "tamagui";
@@ -13,23 +13,23 @@ const GroupList = () => {
     isLoading,
     isError,
     refetch,
-  } = useQuery<Group[]>({ queryKey: ["groups"], queryFn: fetchGroups });
+  } = useSuspenseQuery<Group[]>({ queryKey: ["groups"], queryFn: fetchGroups });
 
   const theme = useTheme();
 
-  if (isLoading) {
-    return null; // 로딩 중에는 아무것도 표시하지 않음
-  }
+  // if (isLoading) {
+  //   return null; // 로딩 중에는 아무것도 표시하지 않음
+  // }
 
-  if (isError) {
-    return (
-      <EmptyPlaceholder
-        icon={<Users size={48} color={theme.color8.val} />}
-        title="오류 발생"
-        message="그룹을 불러오는 데 실패했습니다."
-      />
-    );
-  }
+  // if (isError) {
+  //   return (
+  //     <EmptyPlaceholder
+  //       icon={<Users size={48} color={theme.color8.val} />}
+  //       title="오류 발생"
+  //       message="그룹을 불러오는 데 실패했습니다."
+  //     />
+  //   );
+  // }
 
   if (!groups || groups.length === 0) {
     return (

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,4 +1,5 @@
 import { baseUrl } from "@/constants/api";
+import { useAuthStore } from "@/features/auth/stores/authStore";
 
 import {
   getAccessToken,
@@ -13,6 +14,7 @@ const apiClient = axios.create({
     "ngrok-skip-browser-warning": "true",
   },
 });
+const authClient = axios.create({ baseURL: baseUrl });
 
 export const exchangeCodeForTokens = async (code: string) => {
   const response = await apiClient.post("/api/auth/token", { code });
@@ -20,10 +22,17 @@ export const exchangeCodeForTokens = async (code: string) => {
 };
 
 export const refreshTokenApi = async (token: string) => {
-  const response = await apiClient.post("/api/auth/refresh", {
+  const response = await authClient.post("/api/auth/refresh", {
     refreshToken: token,
   });
   return response.data;
+};
+
+const handleLogout = async (error: unknown) => {
+  await useAuthStore.getState().logout();
+  // 재시도를 방지하기 위해 에러 객체에 커스텀 플래그를 심거나
+  // 즉시 거부된 프로미스를 반환합니다.
+  return Promise.reject(error);
 };
 
 // 인터셉터 외부에 상태를 관리할 변수 선언
@@ -81,8 +90,8 @@ apiClient.interceptors.response.use(
 
     if (!refreshToken) {
       // 리프레시 토큰이 없으면 즉시 로그아웃 처리 함수 호출
-      // logoutHandler(); // TODO: 이 함수는 Auth Context/Store에서 구현해야 함
-      return Promise.reject(error);
+
+      return handleLogout(error);
     }
 
     // 3. 동시성 처리 로직
@@ -125,8 +134,7 @@ apiClient.interceptors.response.use(
       isRefreshing = false;
       processQueue(refreshError); // 큐에 대기 중인 모든 요청에게 실패를 알림
 
-      // logoutHandler(); // TODO: 로그아웃 처리
-      return Promise.reject(refreshError);
+      return handleLogout(refreshError);
     }
   }
 );

--- a/src/services/queryClient.ts
+++ b/src/services/queryClient.ts
@@ -1,0 +1,20 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      // retry: false,
+      retry: (failureCount, error: any) => {
+        if (error.response?.status === 401) {
+          return false; // 401이면 즉시 멈춤
+        }
+        return failureCount < 3; // 그 외 에러는 3번까지 재시도
+      },
+      throwOnError: (error: any) => {
+        // 401이 아닐 때만 에러 바운더리로 전달
+        return error.response?.status !== 401;
+      },
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -730,7 +730,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
 
-"@babel/runtime@^7.18.6", "@babel/runtime@^7.20.0", "@babel/runtime@^7.25.0":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.6", "@babel/runtime@^7.20.0", "@babel/runtime@^7.25.0":
   version "7.28.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
   integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
@@ -5961,6 +5961,13 @@ react-dom@19.1.0:
   dependencies:
     scheduler "^0.26.0"
 
+react-error-boundary@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-6.0.0.tgz#a9e552146958fa77d873b587aa6a5e97544ee954"
+  integrity sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-freeze@^1.0.0, react-freeze@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.4.tgz#cbbea2762b0368b05cbe407ddc9d518c57c6f3ad"
@@ -7195,3 +7202,8 @@ zod@^4.0.5:
   version "4.1.13"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.13.tgz#93699a8afe937ba96badbb0ce8be6033c0a4b6b1"
   integrity sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==
+
+zustand@^5.0.9:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.9.tgz#389dcd0309b9c545d7a461bd3c54955962847654"
+  integrity sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==


### PR DESCRIPTION
## 🚀 주요 변경사항

- Refresh Token을 도입하여 API 요청 시 Access Token이 만료되었을 경우 자동으로 재발급 받도록 구현했습니다.
- Axios Interceptor를 사용하여 API 요청 및 응답을 관리하고, 401 에러 발생 시 Refresh Token으로 새로운 Access Token을 발급받는 로직을 추가했습니다.
- Access Token 재발급 실패 시, 저장된 토큰 정보를 모두 삭제하고 사용자를 로그인 페이지로 이동시켜 재로그인을 유도합니다.
- 로그인 및 토큰 관련 상태를 전역으로 관리하여 애플리케이션의 인증 상태를 일관성 있게 유지합니다.
- 일부 화면에서 발생하던 중첩된 스크롤 문제를 해결했습니다.
- 일기 생성 후 일기 목록이 즉시 업데이트되도록 관련 쿼리를 무효화했습니다.

## 🔗 관련 이슈

- (관련 이슈가 있다면 여기에 추가해주세요)

## ✅ 체크리스트

- [x] Refresh Token 재발급 로직이 정상적으로 동작하는지 확인했습니다.
- [x] Access Token 만료 시 새로운 토큰으로 교체되는 것을 확인했습니다.
- [x] 토큰 재발급 실패 시 로그인 페이지로 이동하는 것을 확인했습니다.